### PR TITLE
Video_PLL base class and more OSC types

### DIFF
--- a/src/main/scala/fpgamacro/gowin/DCS.scala
+++ b/src/main/scala/fpgamacro/gowin/DCS.scala
@@ -17,7 +17,7 @@ class DCS(val pm: Map[String, Param]) extends BlackBox(pm){
     })
 }
 
-/* GATED_CLK (GW1N-1) */
+/* GATED_CLK (GW1N-1, GW1NZ-1, GW1NSR-4C and GW1NR-9) */
 class GATED_CLK() extends RawModule {
   val clkin = IO(Input(Clock()))
   val clkout = IO(Output(Clock()))

--- a/src/main/scala/fpgamacro/gowin/DCS.scala
+++ b/src/main/scala/fpgamacro/gowin/DCS.scala
@@ -1,0 +1,43 @@
+package fpgamacro.gowin
+
+import chisel3._
+import chisel3.util.Cat
+import chisel3.experimental.Param
+
+/* DCS */
+class DCS(val pm: Map[String, Param]) extends BlackBox(pm){
+    val io = IO(new Bundle{
+        val CLKOUT = Output(Clock())
+        val CLKSEL = Input(UInt(4.W))
+        val CLK0 = Input(Clock())
+        val CLK1 = Input(Clock())
+        val CLK2 = Input(Clock())
+        val CLK3 = Input(Clock())
+        val SELFORCE = Input(UInt(1.W))
+    })
+}
+
+/* GATED_CLK (GW1N-1) */
+class GATED_CLK() extends RawModule {
+  val clkin = IO(Input(Clock()))
+  val clkout = IO(Output(Clock()))
+  val clken = IO(Input(Bool()))
+
+  val pm: Map[String, Param] = Map(
+  "DCS_MODE" -> "RISING"
+  )
+
+  val gw_gnd = Wire(Bool())
+
+  gw_gnd := false.B
+
+  val dcs_inst = Module(new DCS(pm))
+
+  dcs_inst.io.CLK0 := clkin
+  dcs_inst.io.CLK1 := gw_gnd.asTypeOf(dcs_inst.io.CLK1)
+  dcs_inst.io.CLK2 := gw_gnd.asTypeOf(dcs_inst.io.CLK2)
+  dcs_inst.io.CLK3 := gw_gnd.asTypeOf(dcs_inst.io.CLK3)
+  dcs_inst.io.CLKSEL := Cat("b0".U(3.W), clken)
+  dcs_inst.io.SELFORCE := gw_gnd
+  clkout := dcs_inst.io.CLKOUT
+}

--- a/src/main/scala/fpgamacro/gowin/OSC.scala
+++ b/src/main/scala/fpgamacro/gowin/OSC.scala
@@ -24,3 +24,50 @@ class Gowin_OSC(FREQ_DIV: Byte = 10) extends RawModule {
 
   io.oscout := osc_inst.io.OSCOUT
 }
+
+/* OSCH */
+class OSCH(val pm: Map[String, Param]) extends BlackBox(pm){
+    val io = IO(new Bundle{
+        val OSCOUT = Output(Clock())
+    })
+}
+
+/* Gowin OSCH (GW1N-1) */
+class Gowin_OSCH(FREQ_DIV: Byte = 10) extends RawModule {
+    val io = IO(new Bundle{
+        val oscout = Output(Clock())
+    })
+
+  val om: Map[String, Param] = Map(
+  "FREQ_DIV" -> FREQ_DIV,
+  )
+
+  val osc_inst = Module(new OSCH(om))
+
+  io.oscout := osc_inst.io.OSCOUT
+}
+
+/* OSCZ */
+class OSCZ(val pm: Map[String, Param]) extends BlackBox(pm){
+    val io = IO(new Bundle{
+        val OSCOUT = Output(Clock())
+        val OSCEN = Input(Bool())
+    })
+}
+
+/* Gowin OSCZ (GW1NZ-1 and GW1NSR-4C) */
+class Gowin_OSCZ(FREQ_DIV: Byte = 10) extends RawModule {
+    val io = IO(new Bundle{
+        val oscout = Output(Clock())
+        val oscen = Input(Bool())
+    })
+
+  val om: Map[String, Param] = Map(
+  "FREQ_DIV" -> FREQ_DIV,
+  )
+
+  val osc_inst = Module(new OSCZ(om))
+
+  io.oscout := osc_inst.io.OSCOUT
+  osc_inst.io.OSCEN := io.oscen
+}

--- a/src/main/scala/fpgamacro/gowin/PLL.scala
+++ b/src/main/scala/fpgamacro/gowin/PLL.scala
@@ -2,6 +2,7 @@ package fpgamacro.gowin
 
 import chisel3._
 import chisel3.util.Cat
+import chisel3.experimental.Param
 
 case class PLLParams(
   val IDIV_SEL: Byte,
@@ -17,4 +18,81 @@ class Video_PLL(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL
         val clkoutd = Output(Clock())
         val clkin = Input(Clock())
     })
+}
+
+/* PLL */
+class PLL(val pm: Map[String, Param]) extends BlackBox(pm){
+    val io = IO(new Bundle{
+        val CLKOUT = Output(Clock())
+        val LOCK = Output(UInt(1.W))
+        val CLKOUTP = Output(Clock())
+        val CLKOUTD = Output(Clock())
+        val CLKOUTD3 = Output(Clock())
+        val RESET = Input(UInt(1.W))
+        val RESET_P = Input(UInt(1.W))
+        val RESET_I = Input(UInt(1.W))
+        val RESET_S = Input(UInt(1.W))
+        val CLKIN = Input(Clock())
+        val CLKFB = Input(Bool())
+        val FBDSEL = Input(UInt(6.W))
+        val IDSEL = Input(UInt(6.W))
+        val ODSEL = Input(UInt(6.W))
+        val PSDA = Input(UInt(4.W))
+        val DUTYDA = Input(UInt(4.W))
+        val FDLY = Input(UInt(4.W))
+    })
+}
+
+/* Gowin PLL (GW1N-1) */
+class Gowin_PLL(pp: PLLParams = PLLParams(IDIV_SEL = 2, FBDIV_SEL = 24, ODIV_SEL = 4, DYN_SDIV_SEL = 6)) extends Video_PLL {
+  val pm: Map[String, Param] = Map(
+  "FCLKIN" -> "24",
+  "DYN_IDIV_SEL" -> "false",
+  "IDIV_SEL" -> pp.IDIV_SEL,
+  "DYN_FBDIV_SEL" -> "false",
+  "FBDIV_SEL" -> pp.FBDIV_SEL,
+  "DYN_ODIV_SEL" -> "false",
+  "ODIV_SEL" -> pp.ODIV_SEL,
+  "PSDA_SEL" -> "0000",
+  "DYN_DA_EN" -> "true",
+  "DUTYDA_SEL" -> "1000",
+  "CLKOUT_FT_DIR" -> "1'b1",
+  "CLKOUTP_FT_DIR" -> "1'b1",
+  "CLKOUT_DLY_STEP" -> 0,
+  "CLKOUTP_DLY_STEP" -> 0,
+  "CLKFB_SEL" -> "internal",
+  "CLKOUT_BYPASS" -> "false",
+  "CLKOUTP_BYPASS" -> "false",
+  "CLKOUTD_BYPASS" -> "false",
+  "DYN_SDIV_SEL" -> pp.DYN_SDIV_SEL,
+  "CLKOUTD_SRC" -> "CLKOUT",
+  "CLKOUTD3_SRC" -> "CLKOUT",
+  )
+
+  val clkoutp_o = Wire(Clock())
+  val clkoutd3_o = Wire(Clock())
+  val gw_gnd = Wire(UInt(1.W))
+
+  gw_gnd := 0.U(1.W)
+
+  val pll_inst = Module(new PLL(pm))
+
+  io.clkout := pll_inst.io.CLKOUT
+  io.lock := pll_inst.io.LOCK
+  clkoutp_o := pll_inst.io.CLKOUTP
+  io.clkoutd := pll_inst.io.CLKOUTD
+  clkoutd3_o := pll_inst.io.CLKOUTD3
+
+  pll_inst.io.RESET := gw_gnd
+  pll_inst.io.RESET_P := gw_gnd
+  pll_inst.io.RESET_I := gw_gnd
+  pll_inst.io.RESET_S := gw_gnd
+  pll_inst.io.CLKIN := io.clkin
+  pll_inst.io.CLKFB := gw_gnd
+  pll_inst.io.FBDSEL := Cat(gw_gnd,gw_gnd,gw_gnd,gw_gnd,gw_gnd,gw_gnd)
+  pll_inst.io.IDSEL := Cat(gw_gnd,gw_gnd,gw_gnd,gw_gnd,gw_gnd,gw_gnd)
+  pll_inst.io.ODSEL := Cat(gw_gnd,gw_gnd,gw_gnd,gw_gnd,gw_gnd,gw_gnd)
+  pll_inst.io.PSDA := Cat(gw_gnd,gw_gnd,gw_gnd,gw_gnd)
+  pll_inst.io.DUTYDA := Cat(gw_gnd,gw_gnd,gw_gnd,gw_gnd)
+  pll_inst.io.FDLY := Cat(gw_gnd,gw_gnd,gw_gnd,gw_gnd)
 }

--- a/src/main/scala/fpgamacro/gowin/PLL.scala
+++ b/src/main/scala/fpgamacro/gowin/PLL.scala
@@ -1,0 +1,20 @@
+package fpgamacro.gowin
+
+import chisel3._
+import chisel3.util.Cat
+
+case class PLLParams(
+  val IDIV_SEL: Byte,
+  val FBDIV_SEL: Byte,
+  val ODIV_SEL: Byte,
+  val DYN_SDIV_SEL: Byte,
+)
+
+class Video_PLL(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 30)) extends RawModule {
+    val io = IO(new Bundle{
+        val clkout = Output(Clock())
+        val lock = Output(Bool())
+        val clkoutd = Output(Clock())
+        val clkin = Input(Clock())
+    })
+}

--- a/src/main/scala/fpgamacro/gowin/PLLVR.scala
+++ b/src/main/scala/fpgamacro/gowin/PLLVR.scala
@@ -4,13 +4,6 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.Param
 
-case class PLLParams(
-  val IDIV_SEL: Byte,
-  val FBDIV_SEL: Byte,
-  val ODIV_SEL: Byte,
-  val DYN_SDIV_SEL: Byte
-)
-
 /* PLLVR */
 class PLLVR(val pm: Map[String, Param]) extends BlackBox(pm){
     val io = IO(new Bundle{
@@ -38,14 +31,7 @@ class PLLVR(val pm: Map[String, Param]) extends BlackBox(pm){
 // PLLParams(IDIV_SEL = 4, FBDIV_SEL = 36, ODIV_SEL = 4, DYN_SDIV_SEL = 16) # CLKOUT_FREQ=200    / 5 = 40.00 MHz
 
 /* TMDS PLLVR */
-class TMDS_PLLVR(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 30)) extends RawModule {
-    val io = IO(new Bundle {
-        val clkin = Input(Clock())
-        val clkout = Output(Clock())
-        val clkoutd = Output(Clock())
-        val lock = Output(Bool())
-    })
-
+class TMDS_PLLVR(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 30)) extends  Video_PLL {
   val pm: Map[String, Param] = Map(
   "FCLKIN" -> "27",
   "DYN_IDIV_SEL" -> "false",

--- a/src/main/scala/fpgamacro/gowin/PLLVR.scala
+++ b/src/main/scala/fpgamacro/gowin/PLLVR.scala
@@ -57,7 +57,7 @@ class TMDS_PLLVR(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SE
   )
 
   val clkoutp_o = Wire(Clock())
-  var clkoutd3_o = Wire(Clock())
+  val clkoutd3_o = Wire(Clock())
   val gw_vcc = Wire(UInt(1.W))
   val gw_gnd = Wire(UInt(1.W))
 
@@ -119,7 +119,7 @@ class GW_PLLVR extends RawModule {
 
   val clkoutp_o = Wire(Clock())
   val clkoutd_o = Wire(Clock())
-  var clkoutd3_o = Wire(Clock())
+  val clkoutd3_o = Wire(Clock())
   val gw_vcc = Wire(UInt(1.W))
   val gw_gnd = Wire(UInt(1.W))
 

--- a/src/main/scala/fpgamacro/gowin/RPLL.scala
+++ b/src/main/scala/fpgamacro/gowin/RPLL.scala
@@ -52,7 +52,7 @@ class Gowin_rPLL(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SE
   )
 
   val clkoutp_o = Wire(Clock())
-  var clkoutd3_o = Wire(Clock())
+  val clkoutd3_o = Wire(Clock())
   val gw_gnd = Wire(UInt(1.W))
 
   gw_gnd := 0.U(1.W)

--- a/src/main/scala/fpgamacro/gowin/RPLL.scala
+++ b/src/main/scala/fpgamacro/gowin/RPLL.scala
@@ -26,14 +26,7 @@ class rPLL(val pm: Map[String, Param]) extends BlackBox(pm){
 }
 
 /* Gowin rPLL (GW1NR-9) */
-class Gowin_rPLL(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 2)) extends RawModule {
-    val io = IO(new Bundle {
-        val clkin = Input(Clock())
-        val clkout = Output(Clock())
-        val clkoutd = Output(Clock())
-        val lock = Output(Bool())
-    })
-
+class Gowin_rPLL(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 2)) extends Video_PLL {
   val pm: Map[String, Param] = Map(
   "FCLKIN" -> "27",
   "DYN_IDIV_SEL" -> "false",

--- a/src/main/scala/fpgamacro/gowin/RPLL.scala
+++ b/src/main/scala/fpgamacro/gowin/RPLL.scala
@@ -4,14 +4,6 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.Param
 
-case class rPLLParams(
-  val IDIV_SEL: Byte,
-  val FBDIV_SEL: Byte,
-  val ODIV_SEL: Byte,
-  val DYN_SDIV_SEL: Byte,
-  val DYN_DA_EN: Param
-)
-
 /* rPLL */
 class rPLL(val pm: Map[String, Param]) extends BlackBox(pm){
     val io = IO(new Bundle{
@@ -34,7 +26,7 @@ class rPLL(val pm: Map[String, Param]) extends BlackBox(pm){
 }
 
 /* Gowin rPLL (GW1NR-9) */
-class Gowin_rPLL(pp: rPLLParams = rPLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 2, DYN_DA_EN = "true")) extends RawModule {
+class Gowin_rPLL(pp: PLLParams = PLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_SEL = 2, DYN_SDIV_SEL = 2)) extends RawModule {
     val io = IO(new Bundle {
         val clkin = Input(Clock())
         val clkout = Output(Clock())
@@ -51,7 +43,7 @@ class Gowin_rPLL(pp: rPLLParams = rPLLParams(IDIV_SEL = 3, FBDIV_SEL = 54, ODIV_
   "DYN_ODIV_SEL" -> "false",
   "ODIV_SEL" -> pp.ODIV_SEL,
   "PSDA_SEL" -> "0000",
-  "DYN_DA_EN" -> pp.DYN_DA_EN,
+  "DYN_DA_EN" -> "true",
   "DUTYDA_SEL" -> "1000",
   "CLKOUT_FT_DIR" -> "1'b1",
   "CLKOUTP_FT_DIR" -> "1'b1",


### PR DESCRIPTION
- Add OSCH and PLL for original TangNano (based on GW1N-1 FPGA)
- Add OSCZ for TangNano-1K (based on GW1NZ-1 FPGA) and TangNano-4K
- Use common Video_PLL base class and PLLParams for all PLL types
