### PR TITLE
generic: Add width parameter for tri-state buffers

### DIFF
--- a/src/main/scala/fpgamacro/generic/tristatebuffer.scala
+++ b/src/main/scala/fpgamacro/generic/tristatebuffer.scala
@@ -59,7 +59,7 @@ class TriStateBufferAtomic(width: Int) extends BlackBox with HasBlackBoxInline {
     |   assign pinout[i] = dir[i] ? inp[i] : 1'bZ;
     | end
     |endgenerate
-    | 
+    |
     |assign outp = pinout;
     |
     |endmodule


### PR DESCRIPTION
This PR adds modularity to tri-state black-boxes by enabling the user to specify the tri-state bus width.

One gate tri-state was replaced by a n-gate tri-state.
16 gates tri-state was replaced by a n-gate atomic tri-state. Here, atomic means "atomic direction change".